### PR TITLE
商品削除機能実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -39,6 +39,14 @@ class ItemsController < ApplicationController
     end
   end  
 
+  def destroy
+    item = Item.find(params[:id])
+    if current_user.id == item.user_id
+      item.destroy
+      redirect_to root_path
+    end
+  end  
+
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -43,8 +43,8 @@ class ItemsController < ApplicationController
     item = Item.find(params[:id])
     if current_user.id == item.user_id
       item.destroy
-      redirect_to root_path
     end
+    redirect_to root_path
   end  
 
   private

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
         <% if current_user.id == @item.user_id %>
             <%= link_to "商品の編集", edit_item_path, date: { turbo: false }, method: :get, class: "item-red-btn" %>
             <p class="or-text">or</p>
-            <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+            <%= link_to "削除", item_path(@item.id), data: { turbo_method: :delete }, class:"item-destroy" %>
         <% else %>
           <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,5 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "articles#index"
   root to: "items#index"
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]
+  resources :items
 end


### PR DESCRIPTION
＃What
商品の削除機能の追加

＃Why
ユーザーが自ら投稿した商品の情報を削除できるようにするため。

ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/dda6061d83f358a9bce5a682093268df